### PR TITLE
fix: code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/provider-build-test.yml
+++ b/.github/workflows/provider-build-test.yml
@@ -1,4 +1,6 @@
 name: CI - Build Provider
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Jamf-Concepts/terraform-provider-jamfautoupdate/security/code-scanning/1](https://github.com/Jamf-Concepts/terraform-provider-jamfautoupdate/security/code-scanning/1)

To fix the issue, add a `permissions` block at the workflow root (above `jobs:`) in `.github/workflows/provider-build-test.yml`. This block should restrict the GITHUB_TOKEN to only have `contents: read`, which is the minimal permission required for the workflow to function correctly (checkout code). No steps in the workflow require write access, so no additional permissions are needed. Add the following block:

```yaml
permissions:
  contents: read
```

This should be placed immediately following the workflow `name:` and before `on:` or `jobs:`. No other imports, definitions, or code changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
