### PR TITLE
Update CODEOWNERS to change maintainer role

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@
 # Format: <pattern> <owner> (use @username for GitHub users)
 
 # Default owner for all files
-* @neilmartin83 @Jamf-Concepts/jamf-concepts-maintainer
+* @neilmartin83 @Jamf-Concepts/jamf-concepts-admin


### PR DESCRIPTION
approver should be admin group. At least until we have Crews to do project-specific. 