### PR TITLE
chore: add @grahampugh as a code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@
 # Format: <pattern> <owner> (use @username for GitHub users)
 
 # Default owner for all files
-* @neilmartin83 @leggatron @jedda-jamf @shanembrown @hoarek
+* @neilmartin83 @leggatron @jedda-jamf @shanembrown @hoarek @grahampugh


### PR DESCRIPTION
Adds `@grahampugh` to the default owner line in `CODEOWNERS`.

No other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)